### PR TITLE
add error message when data and alloc are provided together to Buffer

### DIFF
--- a/src/Buffer.js
+++ b/src/Buffer.js
@@ -40,11 +40,8 @@ export class Buffer {
 			throw new Error('Buffer size exceeds device limit.')
 		}
 
-		if (alloc != null && data == null) {
-			const typedArray = common.arrayConstructors.get(type)
-			this.data = new typedArray(size)
-		}
-		else if (data != null && alloc == null) {
+		if (data != null)
+		{
 			if (data instanceof Uint8ClampedArray) {
 				this.data = new Uint8Array(data.buffer)
 			}
@@ -52,9 +49,12 @@ export class Buffer {
 				this.data = data
 			}
 		}
-		else
-		{
-			throw new Error('data, alloc are provided at the same time.');
+		else if (alloc != null) {
+			const typedArray = common.arrayConstructors.get(type)
+			this.data = new typedArray(size)
+		}
+		else {
+			throw new Error('Must provide args: data or alloc.');
 		}
 	}
 

--- a/src/Buffer.js
+++ b/src/Buffer.js
@@ -40,17 +40,21 @@ export class Buffer {
 			throw new Error('Buffer size exceeds device limit.')
 		}
 
-		if (alloc != null) {
+		if (alloc != null && data == null) {
 			const typedArray = common.arrayConstructors.get(type)
 			this.data = new typedArray(size)
 		}
-		else {
+		else if (data != null && alloc == null) {
 			if (data instanceof Uint8ClampedArray) {
 				this.data = new Uint8Array(data.buffer)
 			}
 			else {
 				this.data = data
 			}
+		}
+		else
+		{
+			throw new Error('data, alloc are provided at the same time.');
 		}
 	}
 


### PR DESCRIPTION
When I provide alloc and data parameter together, I found data is ignored silently.
How about displaying some error message for this?